### PR TITLE
Standardize Logs Across Services [T297884]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.37.0
 	github.com/go-pg/pg/v10 v10.7.4
 	github.com/karrick/godirwalk v1.16.1
+	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.27.0
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.37.0
 	github.com/go-pg/pg/v10 v10.7.4
 	github.com/karrick/godirwalk v1.16.1
-	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.27.0
 )

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/go.sum
+++ b/go.sum
@@ -68,7 +68,10 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,42 @@
+package log
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+var logger = logrus.New()
+
+func init() {
+	logger.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp: true,
+	})
+	logger.SetReportCaller(true)
+}
+
+func Printf(format string, args ...interface{}) {
+	logger.Printf(format, args...)
+}
+
+func Println(args ...interface{}) {
+	logger.Println(args...)
+}
+
+func Panic(args ...interface{}) {
+	logger.Panic(args...)
+}
+
+func Debug(args ...interface{}) {
+	logger.Debug(args...)
+}
+
+func Warning(args ...interface{}) {
+	logger.Warning(args...)
+}
+
+func Error(args ...interface{}) {
+	logger.Error(args...)
+}
+
+func Exit(code int) {
+	logger.Error(code)
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,42 +1,56 @@
+// Package log is a structured logger.
+// The package can be extended with logger library API.
 package log
 
 import (
 	"github.com/sirupsen/logrus"
 )
 
-var logger = logrus.New()
+type Logger interface {
+	SetFormatter(formatter logrus.Formatter)
+	Printf(format string, args ...interface{})
+	Println(args ...interface{})
+	Panic(args ...interface{})
+	Error(args ...interface{})
+	Exit(code int)
+}
+
+var logger Logger
 
 func init() {
+	logger = logrus.New()
+
 	logger.SetFormatter(&logrus.TextFormatter{
 		FullTimestamp: true,
 	})
-	logger.SetReportCaller(true)
 }
 
+// SetLogger sets the logger instance
+func SetLogger(l Logger) {
+	logger = l
+}
+
+// Printf call logrus Printf
 func Printf(format string, args ...interface{}) {
 	logger.Printf(format, args...)
 }
 
+// Println call logrus Println
 func Println(args ...interface{}) {
 	logger.Println(args...)
 }
 
+// Panic call logrus Panic
 func Panic(args ...interface{}) {
 	logger.Panic(args...)
 }
 
-func Debug(args ...interface{}) {
-	logger.Debug(args...)
-}
-
-func Warning(args ...interface{}) {
-	logger.Warning(args...)
-}
-
+// Error call logrus Error
 func Error(args ...interface{}) {
 	logger.Error(args...)
 }
 
+// Exit call logrus Exit
 func Exit(code int) {
-	logger.Error(code)
+	logger.Exit(code)
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -6,9 +6,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type Logger interface {
-	SetFormatter(formatter logrus.Formatter)
+type WithFielder interface {
 	WithFields(fields logrus.Fields) *logrus.Entry
+}
+
+type Formatter interface {
+	SetFormatter(formatter logrus.Formatter)
+}
+
+type Printer interface {
 	Printf(format string, args ...interface{})
 	Println(args ...interface{})
 	Debug(args ...interface{})
@@ -16,7 +22,12 @@ type Logger interface {
 	Warn(args ...interface{})
 	Panic(args ...interface{})
 	Error(args ...interface{})
-	Exit(code int)
+}
+
+type Logger interface {
+	WithFielder
+	Formatter
+	Printer
 }
 
 var logger Logger
@@ -33,7 +44,7 @@ func SetLogger(l Logger) {
 }
 
 // WithFields call logrus WithFields
-func WithFields(fields map[string]interface{}) *logrus.Entry {
+func WithFields(fields map[string]interface{}) Printer {
 	return logger.WithFields(fields)
 }
 
@@ -70,9 +81,4 @@ func Panic(args ...interface{}) {
 // Error call logrus Error
 func Error(args ...interface{}) {
 	logger.Error(args...)
-}
-
-// Exit call logrus Exit
-func Exit(code int) {
-	logger.Exit(code)
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -6,14 +6,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// WithFielder is an interface that wraps WithFields methods for unit testing
 type WithFielder interface {
 	WithFields(fields logrus.Fields) *logrus.Entry
 }
 
+// Formatter is an interface that wraps SetFormatter methods for unit testing
 type Formatter interface {
 	SetFormatter(formatter logrus.Formatter)
 }
 
+// Printer is an interface that wraps logrus print methods for unit testing
 type Printer interface {
 	Printf(format string, args ...interface{})
 	Println(args ...interface{})
@@ -24,6 +27,7 @@ type Printer interface {
 	Error(args ...interface{})
 }
 
+// Logger is an interface that wraps all required logger methods for unit testing
 type Logger interface {
 	WithFielder
 	Formatter

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -8,8 +8,12 @@ import (
 
 type Logger interface {
 	SetFormatter(formatter logrus.Formatter)
+	WithFields(fields logrus.Fields) *logrus.Entry
 	Printf(format string, args ...interface{})
 	Println(args ...interface{})
+	Debug(args ...interface{})
+	Info(args ...interface{})
+	Warn(args ...interface{})
 	Panic(args ...interface{})
 	Error(args ...interface{})
 	Exit(code int)
@@ -20,14 +24,17 @@ var logger Logger
 func init() {
 	logger = logrus.New()
 
-	logger.SetFormatter(&logrus.TextFormatter{
-		FullTimestamp: true,
-	})
+	logger.SetFormatter(&logrus.JSONFormatter{})
 }
 
 // SetLogger sets the logger instance
 func SetLogger(l Logger) {
 	logger = l
+}
+
+// WithFields call logrus WithFields
+func WithFields(fields map[string]interface{}) *logrus.Entry {
+	return logger.WithFields(fields)
 }
 
 // Printf call logrus Printf
@@ -38,6 +45,21 @@ func Printf(format string, args ...interface{}) {
 // Println call logrus Println
 func Println(args ...interface{}) {
 	logger.Println(args...)
+}
+
+// Debug call logrus Debug
+func Debug(args ...interface{}) {
+	logger.Debug(args...)
+}
+
+// Info call logrus Info
+func Info(args ...interface{}) {
+	logger.Info(args...)
+}
+
+// Warn call logrus Warn
+func Warn(args ...interface{}) {
+	logger.Warn(args...)
 }
 
 // Panic call logrus Panic

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,0 +1,1 @@
+package log

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,9 +1,10 @@
 package log
 
 import (
+	"testing"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/mock"
-	"testing"
 )
 
 // Mock object for logger
@@ -58,11 +59,6 @@ func (l *loggerMock) Error(args ...interface{}) {
 	l.Called(args)
 }
 
-// Mock logger Exit method behaviour
-func (l *loggerMock) Exit(code int) {
-	l.Called(code)
-}
-
 const logTestPrintfFormat = "Format"
 const logTestPrintfLog = "run Printf"
 const logTestPrintlnLog = "run Println"
@@ -71,7 +67,6 @@ const logTestInfoLog = "run Info"
 const logTestWarnLog = "run Warn"
 const logTestPanicLog = "run Panic"
 const logTestErrorLog = "run Error"
-const logTestExitCode = 1
 
 func TestLogger(t *testing.T) {
 	loggerObj := new(loggerMock)
@@ -84,7 +79,6 @@ func TestLogger(t *testing.T) {
 	loggerObj.On("Warn", []interface{}{logTestWarnLog})
 	loggerObj.On("Panic", []interface{}{logTestPanicLog})
 	loggerObj.On("Error", []interface{}{logTestErrorLog})
-	loggerObj.On("Exit", logTestExitCode)
 
 	SetLogger(loggerObj)
 
@@ -96,5 +90,4 @@ func TestLogger(t *testing.T) {
 	Warn(logTestWarnLog)
 	Panic(logTestPanicLog)
 	Error(logTestErrorLog)
-	Exit(logTestExitCode)
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,1 +1,67 @@
 package log
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/mock"
+	"testing"
+)
+
+// Mock object for logger
+type loggerMock struct {
+	mock.Mock
+}
+
+// Mock logger SetFormatter method behaviour
+func (l *loggerMock) SetFormatter(formatter logrus.Formatter) {
+	l.Called(formatter)
+}
+
+// Mock logger Printf method behaviour
+func (l *loggerMock) Printf(format string, args ...interface{}) {
+	l.Called(format, args)
+}
+
+// Mock logger Println method behaviour
+func (l *loggerMock) Println(args ...interface{}) {
+	l.Called(args)
+}
+
+// Mock logger Panic method behaviour
+func (l *loggerMock) Panic(args ...interface{}) {
+	l.Called(args)
+}
+
+// Mock logger Error method behaviour
+func (l *loggerMock) Error(args ...interface{}) {
+	l.Called(args)
+}
+
+// Mock logger Exit method behaviour
+func (l *loggerMock) Exit(code int) {
+	l.Called(code)
+}
+
+const logTestPrintfFormat = "Format"
+const logTestPrintfLog = "run Printf"
+const logTestPrintlnLog = "run Println"
+const logTestPanicLog = "run Panic"
+const logTestErrorLog = "run Error"
+const logTestExitCode = 1
+
+func TestLogger(t *testing.T) {
+	loggerObj := new(loggerMock)
+
+	loggerObj.On("Printf", logTestPrintfFormat, []interface{}{logTestPrintfLog})
+	loggerObj.On("Println", []interface{}{logTestPrintlnLog})
+	loggerObj.On("Panic", []interface{}{logTestPanicLog})
+	loggerObj.On("Error", []interface{}{logTestErrorLog})
+	loggerObj.On("Exit", logTestExitCode)
+
+	SetLogger(loggerObj)
+
+	Printf(logTestPrintfFormat, logTestPrintfLog)
+	Println(logTestPrintlnLog)
+	Panic(logTestPanicLog)
+	Error(logTestErrorLog)
+	Exit(logTestExitCode)
+}

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -16,6 +16,13 @@ func (l *loggerMock) SetFormatter(formatter logrus.Formatter) {
 	l.Called(formatter)
 }
 
+// Mock logger WithFields method behaviour
+func (l *loggerMock) WithFields(fields logrus.Fields) *logrus.Entry {
+	args := l.Called(fields)
+
+	return args.Get(0).(*logrus.Entry)
+}
+
 // Mock logger Printf method behaviour
 func (l *loggerMock) Printf(format string, args ...interface{}) {
 	l.Called(format, args)
@@ -23,6 +30,21 @@ func (l *loggerMock) Printf(format string, args ...interface{}) {
 
 // Mock logger Println method behaviour
 func (l *loggerMock) Println(args ...interface{}) {
+	l.Called(args)
+}
+
+// Mock logger Debug method behaviour
+func (l *loggerMock) Debug(args ...interface{}) {
+	l.Called(args)
+}
+
+// Mock logger Info method behaviour
+func (l *loggerMock) Info(args ...interface{}) {
+	l.Called(args)
+}
+
+// Mock logger Warn method behaviour
+func (l *loggerMock) Warn(args ...interface{}) {
 	l.Called(args)
 }
 
@@ -44,6 +66,9 @@ func (l *loggerMock) Exit(code int) {
 const logTestPrintfFormat = "Format"
 const logTestPrintfLog = "run Printf"
 const logTestPrintlnLog = "run Println"
+const logTestDebugLog = "run Debug"
+const logTestInfoLog = "run Info"
+const logTestWarnLog = "run Warn"
 const logTestPanicLog = "run Panic"
 const logTestErrorLog = "run Error"
 const logTestExitCode = 1
@@ -51,16 +76,24 @@ const logTestExitCode = 1
 func TestLogger(t *testing.T) {
 	loggerObj := new(loggerMock)
 
+	loggerObj.On("WithFields", logrus.Fields{"name": "field1"}).Return(new(logrus.Entry))
 	loggerObj.On("Printf", logTestPrintfFormat, []interface{}{logTestPrintfLog})
 	loggerObj.On("Println", []interface{}{logTestPrintlnLog})
+	loggerObj.On("Debug", []interface{}{logTestDebugLog})
+	loggerObj.On("Info", []interface{}{logTestInfoLog})
+	loggerObj.On("Warn", []interface{}{logTestWarnLog})
 	loggerObj.On("Panic", []interface{}{logTestPanicLog})
 	loggerObj.On("Error", []interface{}{logTestErrorLog})
 	loggerObj.On("Exit", logTestExitCode)
 
 	SetLogger(loggerObj)
 
+	WithFields(logrus.Fields{"name": "field1"})
 	Printf(logTestPrintfFormat, logTestPrintfLog)
 	Println(logTestPrintlnLog)
+	Debug(logTestDebugLog)
+	Info(logTestInfoLog)
+	Warn(logTestWarnLog)
 	Panic(logTestPanicLog)
 	Error(logTestErrorLog)
 	Exit(logTestExitCode)


### PR DESCRIPTION
# Summary
Implement "logger" with logrus package.

## Details
Not all logrus methods have been integrated.
List of methods:
* `Printf`
* `Println`
* `Panic`
* `Error`
* `Exit`

Screenshot:
<img width="599" alt="Screen Shot 2022-02-06 at 3 20 09 PM" src="https://user-images.githubusercontent.com/61981712/152699848-107ac099-ef9d-4578-8b6b-e3d30b32e42e.png">

when a TTY is not attached

<img width="818" alt="Screen Shot 2022-02-06 at 3 50 20 PM" src="https://user-images.githubusercontent.com/61981712/152700878-c10ab955-60a9-4ba8-ae1e-1baf693f7709.png">

